### PR TITLE
Increase the maximum number of page result sets to 24

### DIFF
--- a/js/gradesexport.js
+++ b/js/gradesexport.js
@@ -204,7 +204,7 @@
 // 						.end()
 						.append(courseOptions);
 
-					if (data['PagingInfo']['HasMoreItems'] && successCounter < 4) {
+					if (data['PagingInfo']['HasMoreItems'] && successCounter < 24) {
 						// if the user has more enrollments left to load, call myenrollments
 						// again with the provided Bookmark value
 						var url = GradesExport.userContext.createUrlForAuthentication('/d2l/api/lp/1.4/enrollments/myenrollments/', 'GET');


### PR DESCRIPTION
Increase the maximum number of fetched page result sets from 4 to 24
when getting an instructor's course enrollments. Otherwise, instructors
with a large number of course enrollments cannot see their most recent
courses.

At the moment, 5 pages is actually sufficient. But, there's no real
harm in setting this higher. The limit was originally set to avoid
runaway loops.

Resolves #12.